### PR TITLE
[pleasereview] add trait ParseLog

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -151,10 +151,10 @@ fn get_option<'a>(options: &'a [syn::MetaItem], name: &str) -> Result<&'a str> {
 }
 
 fn str_value_of_meta_item<'a>(item: &'a syn::MetaItem, name: &str) -> Result<&'a str> {
-    match *item {
-        syn::MetaItem::NameValue(_, syn::Lit::Str(ref value, _)) => Ok(&*value),
-        _ => Err(format!(r#"`{}` must be in the form `#[{}="something"]`"#, name, name).into()),
-    }
+	match *item {
+		syn::MetaItem::NameValue(_, syn::Lit::Str(ref value, _)) => Ok(&*value),
+		_ => Err(format!(r#"`{}` must be in the form `#[{}="something"]`"#, name, name).into()),
+	}
 }
 
 fn normalize_path(relative_path: &str) -> Result<PathBuf> {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -397,6 +397,7 @@ fn declare_logs(event: &Event) -> quote::Tokens {
 		.collect();
 
 	quote! {
+		#[derive(Debug)]
 		pub struct #name {
 			#(#params)*
 		}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -49,6 +49,7 @@ fn impl_ethabi_derive(ast: &syn::DeriveInput) -> Result<quote::Tokens> {
 		quote! {
 			pub mod events {
 				use ethabi;
+				use ethabi::ParseLog;
 
 				#(#events_structs)*
 			}
@@ -504,15 +505,20 @@ fn declare_events(event: &Event) -> quote::Tokens {
 			}
 		}
 
-		impl #name {
+		impl ParseLog for #name {
+			type Log = super::logs::#name;
+
 			/// Parses log.
-			pub fn parse_log(&self, log: ethabi::RawLog) -> ethabi::Result<super::logs::#name> {
+			fn parse_log(&self, log: ethabi::RawLog) -> ethabi::Result<Self::Log> {
 				let mut log = self.event.parse_log(log)?.params.into_iter();
 				let result = super::logs::#name {
 					#(#log_params),*
 				};
 				Ok(result)
 			}
+		}
+
+		impl #name {
 
 			/// Creates topic filter.
 			pub fn create_filter<#(#template_params),*>(&self, #(#params),*) -> ethabi::TopicFilter {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -520,7 +520,6 @@ fn declare_events(event: &Event) -> quote::Tokens {
 		}
 
 		impl #name {
-
 			/// Creates topic filter.
 			pub fn create_filter<#(#template_params),*>(&self, #(#params),*) -> ethabi::TopicFilter {
 				let raw = ethabi::RawTopicFilter {

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -43,7 +43,7 @@ pub use decoder::decode;
 pub use filter::{Topic, TopicFilter, RawTopicFilter};
 pub use function::Function;
 pub use param::Param;
-pub use log::{Log, RawLog, LogParam};
+pub use log::{Log, RawLog, LogParam, ParseLog};
 pub use event::Event;
 pub use event_param::EventParam;
 

--- a/ethabi/src/log.rs
+++ b/ethabi/src/log.rs
@@ -1,4 +1,15 @@
-use {Hash, Token, Bytes};
+use {Hash, Token, Bytes, Result};
+
+/// trait common to things (events) that have an associated `Log` type
+/// that can be parsed from a `RawLog`
+pub trait ParseLog {
+	/// the associated `Log` type that can be parsed from a `RawLog`
+	/// by calling `parse_log`
+	type Log;
+
+	/// parse the associated `Log` type from a `RawLog`
+	fn parse_log(&self, log: RawLog) -> Result<Self::Log>;
+}
 
 /// Ethereum log.
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
moves the `parse_log` function common to all derived events into a trait `ParseLog` so functions can be generic over events/things that can be parsed from `RawLog`s

required for https://github.com/paritytech/sol-rs/pull/14